### PR TITLE
fix: maintain insertion order of Map/Set instances during decoding

### DIFF
--- a/src/turbo-stream.spec.ts
+++ b/src/turbo-stream.spec.ts
@@ -120,6 +120,21 @@ test("should encode and decode Map", async () => {
   expect(output).toEqual(input);
 });
 
+test("should preserve order for decoded Maps", async () => {
+  let input = new Map([
+    [1, 1],
+    [2, 2],
+    [3, 3],
+  ]);
+  const decoded = await decode(encode(input));
+  const value = decoded.value as typeof input;
+  expect(Array.from(value.entries())).toEqual([
+    [1, 1],
+    [2, 2],
+    [3, 3],
+  ]);
+});
+
 test("should encode and decode empty Map", async () => {
   const input = new Map();
   const output = await quickDecode(encode(input));
@@ -130,6 +145,13 @@ test("should encode and decode Set", async () => {
   const input = new Set(["foo", "bar"]);
   const output = await quickDecode(encode(input));
   expect(output).toEqual(input);
+});
+
+test("should preserve order for decoded Sets", async () => {
+  let input = new Set([1, 2, 3]);
+  const decoded = await decode(encode(input));
+  const value = decoded.value as typeof input;
+  expect(Array.from(value.values())).toEqual([1, 2, 3]);
 });
 
 test("should encode and decode empty Set", async () => {

--- a/src/unflatten.ts
+++ b/src/unflatten.ts
@@ -98,6 +98,7 @@ function hydrate(this: ThisDecode, index: number): any {
     if (Array.isArray(value)) {
       if (typeof value[0] === "string") {
         const [type, b, c] = value;
+        let pos: number;
         switch (type) {
           case TYPE_DATE:
             set((hydrated[index] = new Date(b)));
@@ -117,18 +118,21 @@ function hydrate(this: ThisDecode, index: number): any {
           case TYPE_SET:
             const newSet = new Set();
             hydrated[index] = newSet;
-            for (let i = 1; i < value.length; i++)
-              stack.push([
+            pos = stack.length;
+            for (let i = 1; i < value.length; i++) {
+              stack.splice(pos, 0, [
                 value[i],
                 (v) => {
                   newSet.add(v);
                 },
               ]);
+            }
             set(newSet);
             continue;
           case TYPE_MAP:
             const map = new Map();
             hydrated[index] = map;
+            pos = postRun.length;
             for (let i = 1; i < value.length; i += 2) {
               const r: any[] = [];
               stack.push([
@@ -143,7 +147,7 @@ function hydrate(this: ThisDecode, index: number): any {
                   r[0] = k;
                 },
               ]);
-              postRun.push(() => {
+              postRun.splice(pos, 0, () => {
                 map.set(r[0], r[1]);
               });
             }


### PR DESCRIPTION
Addresses https://github.com/remix-run/react-router/pull/13093

@jacob-ebey We just need to create a `v2` branch off of `bc545ccf1e036dd4e3cd08d00d03efd4187cfa00` in the origin repo and I can repoint this PR to that.